### PR TITLE
Update info53k.md

### DIFF
--- a/content/implementations/LT/info53k.md
+++ b/content/implementations/LT/info53k.md
@@ -1,28 +1,39 @@
 ---
-title: ""
-date: 2020-12-09T11:39:38+02:00 
-draft: true
+title: "Article 58(1), p.12 of the Law No VIII- 1185 on Copyright and Related Rights"
+date: 2003-03-05
+draft: false
 weight: 61
 exceptions:
 - info53k
 jurisdictions:
 - LT
 score: 
-description: "" 
+description: "This exception allows for the use of performances, phonograms, film fixations and broadcasts for the purpose of caricature or parody. Indicating the source, including the author’s name, is required, whenever possible." 
 beneficiaries:
-- 
+- any user
 purposes: 
-- 
+- caricature or parody
 usage:
-- 
+- any use
 subjectmatter:
-- 
+- performances
+- phonograms
+- film fixations 
+- broadcasts
 compensation:
--
+- no compensation required
 attribution: 
--
+- indicating the source, including the author’s name is required, whenever possible
 otherConditions: 
-- 
-remarks: ""
-link: 
+remarks: "The exception covers no pastiche.
+
+The Lithuanian parody exception for copyrighted works was removed in 2011, leaving the corresponding neighbouring rights exception behind. Currently the law, in terms of litteral reading, provides for an exemption for the purposes of parody and caricature solely regarding neighbouring rights.
+
+In a decision (Nr. 3K-3-214/2009), preceding the CJEU Deckmyn case, the Supreme Court of the Republic of Lithuania ruled that the use of a work for the purpose of parody was permitted under the following conditions: 
+i) the parody is an imitation of the copyrighted work, 
+ii) the use of a work is humoristic, 
+iii) the parodied work is the target of parody, 
+iv) the parody is an original work, 
+v) the use of a work for the purpose of parody meets the three-step test requirements (do not conflict with a normal exploitation of the work or other subject-matter and do not unreasonably prejudice the legitimate interests of the right holder)."
+link: https://www.wipo.int/edocs/lexdocs/laws/en/lt/lt081en.pdf
 ---


### PR DESCRIPTION
Added additional info to 'Remarks'. So it turned out the parody exception for copyrighted works was removed in 2011, but one regarding related rights was not.