### PR TITLE
Overall update after test update of info53a.md

### DIFF
--- a/content/implementations/PT/info53a.md
+++ b/content/implementations/PT/info53a.md
@@ -8,16 +8,16 @@ exceptions:
 jurisdictions:
 - PT
 score: 2
-description: "The national exceptions are similar to the EU exception with regards to who can benefit from the exception and the materials that can be used. The national exceptions are more restrictive than the EU exception with regards to the type of activities that can be done and the purposes of the activities. The national exceptions require attribution and do not require the payment of compensation for most uses. The national exceptions have further restrictions." 
+description: "Portugal has two exceptions covering educational uses of parts of works (Art. 75(2)(f) and (g)) and one exception covering the use of performances, phonograms, film fixations and broadcasts for educational and scientific purposes (Art. 189(1)(c)). The exceptions are open to all users and cover almost all types of activities. Most uses are not subject to compensation." 
 beneficiaries:
 - Any users
 purposes: 
 - Educational purposes
-- Scientific purposes 
+- Scientific purposes (it does not apply to works) 
 usage:
 - Reproduction
 - Distribution
-- Public Communication 
+- Public Communication (it does not apply to works)
 - Making available to the public
 subjectmatter:
 - Works
@@ -26,13 +26,14 @@ subjectmatter:
 - Film fixations
 - Broadcasts
 compensation:
-- Some uses
+- "Uses of works for purposes of creating teaching materials are subject to compensation; other uses are not"
 attribution:
-- "Yes"
+- "Uses of works require attribution; uses of performances, phonograms, film fixations and broadcasts do not"
 otherConditions: 
-- Non-commercial Purposes
-- Quantity Limitations
-- 3-step test 
-remarks: "There are 3 exceptions in the Portuguese law that implement Art. 5.3(a) InfoSoc.: two cover the use of copyright-protected works (Art. 75(2)(f) and (g)) and one covers the use of subject matter protected by neighbouring rights under the InfoSoc (i.e. performances, phonograms, film fixations and broadcasts) (Art. 189(1)(c)).<br /><br />The exception that applies to subject matter protected by neighbouring rights covers uses both for educational and scientific purposes, whereas the exceptions that apply to copyright-protected works do not cover scientific purposes.<br /><br /> The exception that applies to subject matter protected by neighbouring rights covers any uses. The main exception permitting the use of copyright-protected works covers reproduction, distribution and making available to the public for teaching purposes (Art. 75(2)(f)); the other allows the inclusion of works for purposes of creating teaching materials (Art. 75(2)(h)).<br /><br />The exceptions that allow the use of copyright-protected works (Art. 75(2)(f) and (g)) are conditioned to the use of parts of works, but one of them (Art. 75(2)(h)) allows the use of short works in their entirety. The exception that applies to subject matter protected by neighbouring rights does not restrict the portion to which a material can be used. The main exception permitting the use of copyright-protected works (Art. 75(2)(f)) is conditioned to uses that are exclusively related to the teaching objectives in the “establishments” (implying that the exception only covers formal activities, but without specifying which establishments are those) and that do not aim to obtain, directly or indirectly, an economic or commercial advantage. The other two exceptions do not have any such limitations.<br /><br />The exceptions that permit the use of copyright-protected works (Art. 75(2)(f) and (g)) are subject to the 3-step test. The exception that applies to subject matter protected by neighbouring rights does not have any such limitation. The exception that covers the creation of teaching materials (Art. 75(2)(h)) is the only one that is subject to compensation."
-link: ""
+- Quantity Limitations: "uses of works are limited to parts of works (but short works can be used in their entirety if the use is for purposes of creating teaching materials)"
+- Non-commercial Purposes: "some uses of works must not be aimed at obtaining, directly or indirectly, an economic or commercial advantage" 
+- 3-step test: "uses of works must not conflict with a normal exploitation of the work and not unreasonably prejudice the legitimate interests of the author" 
+remarks: "Portugal has two exceptions covering educational uses of works (Art. 75(2)(f) and (g)) and one exception covering the use of performances, phonograms, film fixations and broadcasts for educational and scientific purposes (Art. 189(1)(c)).<br /><br /> The main exception permitting the use of works for teaching purposes (Art. 75(2)(f)) is open to all users, but it is conditioned to uses that are exclusively related to the teaching objectives in the “establishments” (implying that the exception only covers formal activities, but without specifying which establishments are those). This exception allows reproduction, distribution and making available to the public of works. This exception is not subject to compensation. This exception requires attribution, is subject to the 3-step test, is subject to quantity limitations (it only allows the use of parts of works), and it requires that the uses are not aimed at obtaining, directly or indirectly, an economic or commercial advantage.<br /><br />The other exception allows the inclusion of works for purposes of creating teaching materials (Art. 75(2)(h)). This exception is subject to compensation, requires attribution, it is subject to the 3-step test and to quantity limitations (it only allows the use of parts of works or short works in their entirety).<br /><br /> The exception that applies to subject matter protected by neighbouring rights (Art. 189(1)(c)) is open to all users and it covers any uses both for educational and scientific purposes. This exception is not subject to compensation, does not require attribution, it is not subject to the 3-step test and it does not have any further conditions."
+Introduced/last updated: "24 August 2004"
+link: "https://www.pgdlisboa.pt/leis/lei_mostra_articulado.php?artigo_id=484A0075&nid=484&tabela=leis&pagina=1&ficha=1&so_miolo=&nversao=#artigo"
 ---


### PR DESCRIPTION
Improved the description; clarified that the exceptions that apply to works do not cover scientific purposes and public communication; specified which uses require compensation and which uses require attribution; described the other conditions that were enumerated; deleted the previous remarks and inserted a new text that is more accessible for the average reader; inserted the date that the exception was last updated; inserted the link to the national law