### PR TITLE
Update info52d.md

### DIFF
--- a/content/implementations/FR/info52d.md
+++ b/content/implementations/FR/info52d.md
@@ -1,13 +1,13 @@
 ---
 title: ""
-date: 2020-12-09T11:39:34+02:00 
-draft: true
+date: 2021-03-18
+draft: false
 weight: 43
 exceptions:
 - info52d
 jurisdictions:
 - FR
-score: 
+score: 0
 description: "" 
 beneficiaries:
 - 


### PR DESCRIPTION
Filled in. Not transposed (IMO).
I have two separate sources stating that 5.2.d. is implemented in Art. L 214-1-2° (but I don't think this is any near ephemeral recordings): 
"Where a phonogram has been published for commercial purposes, the performer and the producer may not oppose: 
(...) 2° Its broadcasting and its simultaneous and integral cable distribution, as well as its reproduction strictly reserved for those purposes, performed by or on behalf of audiovisual communication companies in order to add sound to their own programs broadcast on their own channels as well as on those of audiovisual communication companies who pay fair compensation." 
I need help with the interpretation.