### PR TITLE
Update info53c-1.md

### DIFF
--- a/content/implementations/ES/info53c-1.md
+++ b/content/implementations/ES/info53c-1.md
@@ -1,28 +1,32 @@
 ---
-title: ""
-date: 2020-12-09T11:39:41+02:00 
-draft: true
+title: "Article 33(1) of Law 23/2006"
+date: 2006-07-08
+draft: false
 weight: 52
 exceptions:
 - info53c-1
 jurisdictions:
 - ES
-score: 
-description: "" 
+score: 2
+description: "This exception allows for the reproduction, distribution, and public communication by mass media of works and articles on current affairs published by mass media unless the rightsholder has originally stated reservation of rights. 'Literary collaborations' are explicitly excluded from the scope of the exception. The provision requires attribution to the source and author (if the work was divulged bearing a signature) as well as the payment of agreed remuneration, or in the absence of agreement, the remuneration deemed equitable."
 beneficiaries:
-- 
+- mass media
 purposes: 
-- 
+- works and articles on current affairs
 usage:
-- 
+- reproduction 
+- distribution
+- public communication
 subjectmatter:
-- 
+- works and articles on current affairs
 compensation:
--
+- payment of agreed remuneration, or in the absence of agreement, the remuneration deemed equitable
 attribution: 
--
+- attribution to the source and author is required, if the work was divulged bearing a signature
 otherConditions: 
-- 
-remarks: ""
-link: 
+- authors can explicitly forbid use under the exception (opt-out option)
+- works used must be published by mass media
+- 'literary collaborations' are explicitly excluded from the scope of the exception
+remarks: "This analysis does not take into account the so-called 'press clippings' exception under the second part of art. 32(1) of the Spanish law ('_Periodic compilations made in the form of reviews or press reviews will be considered citations_') and the so-called 'Google tax' (art.32(2), applicable to both search engines and content aggregation), as they do not comply with the requirements of the first hypothesis of art. 5(3)(d) of the Infosoc Directive, thus cannot be deemed to implement it.<br /><br />The exception applies to neighbouring rights on the basis of the general provision of Art. 132 of the Law."
+link: https://wipolex.wipo.int/en/text/507842
 ---


### PR DESCRIPTION
Filled in. Again, left art. 32 paras 1 and 2 out. The so-called 'press clippings' exception is said to apply to 'press reviews', but I don't think it complies with the requirements of the actual 'press review' exception - doesn't have an informative purpose, is not restricted to the use of articles on current events, nor does it provide for an opt-out option for the rightsholder.

Not sure how to interpret the compensation requirement.