### PR TITLE
Update info53c-1.md

### DIFF
--- a/content/implementations/SI/info53c-1.md
+++ b/content/implementations/SI/info53c-1.md
@@ -1,28 +1,21 @@
 ---
 title: ""
-date: 2020-12-09T11:39:41+02:00 
-draft: true
+date: 2022-05-03
+draft: false
 weight: 52
 exceptions:
 - info53c-1
 jurisdictions:
 - SI
-score: 
+score: 0
 description: "" 
 beneficiaries:
-- 
 purposes: 
-- 
 usage:
-- 
 subjectmatter:
-- 
 compensation:
--
 attribution: 
--
 otherConditions: 
-- 
-remarks: ""
+remarks: "The provision of art. 48(1)2 of the Slovenian Copyright Law can be regarded as a 'press review' exception because it covers the 'preparation and reproduction of abstracts of published newspaper and similar articles in the form of press reviews'. However, art. 48(1)2 does not meet two basic requirements of the respective InfoSoc provision of the 1st hypothesis of art.5(3)(c) - (i) the limitation of the thematic scope of the works used to current economic, political or religious topics and (ii) the reservation option in favour of the rightsholder. At the same time, art. 48(1)2 expressly limits the use to the purpose of informing the public, which is a typical characteristic of the 'reporting of current events' exception. This is why it is submitted that the 'press review' exception is not transposed proper in Slovenia and the 'preparation and reproduction of abstracts of published newspaper and similar articles in the form of press reviews' is regarded as part of the 'reporting of current events' exception's implementation."
 link: 
 ---


### PR DESCRIPTION
I was wandering how to proceed with this one, but ultimately assumed that it was not transposed and added an explication in the 'remarks' section:
The provision of art. 48(1)2 of the Slovenian Copyright Law can be regarded as a 'press review' exception because it covers the 'preparation and reproduction of abstracts of published newspaper and similar articles in the form of press reviews'. However, art. 48(1)2 does not meet two basic requirements of the respective InfoSoc provision of the 1st hypothesis of art.5(3)(c) - (i) the limitation of the thematic scope of the works used to current economic, political or religious topics and (ii) the reservation option in favour of the rightsholder. At the same time, art. 48(1)2 expressly limits the use to the purpose of informing the public, which is a typical characteristic of the 'reporting of current events' exception. This is why it is submitted that the 'press review' exception is not transposed proper in Slovenia and the 'preparation and reproduction of abstracts of published newspaper and similar articles in the form of press reviews' is regarded as part of the 'reporting of current events' exception's implementation.