### PR TITLE
Update info53h.md

### DIFF
--- a/content/implementations/SI/info53h.md
+++ b/content/implementations/SI/info53h.md
@@ -1,28 +1,28 @@
 ---
-title: ""
-date: 2020-12-09T11:39:41+02:00 
-draft: true
+title: "Article 55 of the Copyright and Related Rights Act"
+date: 2004-04-26
+draft: false
 weight: 58
 exceptions:
 - info53h
 jurisdictions:
 - SI
-score: 
-description: "" 
+score: 2
+description: "This exception allows for the use of works permanently placed in parks, streets, squares, or other generally accessible premises. Reproduction in a three-dimensional form, used for the same purpose as the original work, or used for economic gain, is expressly excluded from the scope of the exception. The source and authorship of the work must be indicated, if the latter is indicated on the work used." 
 beneficiaries:
-- 
+- any user
 purposes: 
-- 
+- not specified
 usage:
-- 
+- any use (except reproduction in a three-dimensional form, used for the same purpose as the original work, or used for economic gain)
 subjectmatter:
-- 
+- works (permanently placed in parks, streets, squares, or other generally accessible premises)
 compensation:
--
+- no compensation required
 attribution: 
--
+- the source and authorship of the work must be indicated, if the latter is indicated on the work used
 otherConditions: 
-- 
-remarks: ""
-link: 
+- works used must be permanently placed in parks, streets, squares, or other generally accessible premises
+remarks: "According to Article 4 of the CRRA, the provisions on 'the substantive restrictions on copyright' apply mutatis mutandis to related rights, unless otherwise provided in Chapter Five of the Act."
+link: https://wipolex.wipo.int/en/text/422515
 ---


### PR DESCRIPTION
Info filled in.
It's a broad exception, so I am giving it a 3 notwithstanding the exclusion of 3D copies for commercial purposes, because that type of 'substitution' IMO would not pass the 3-step test anyway.