### PR TITLE
Update info52a.md

### DIFF
--- a/content/implementations/HR/info52a.md
+++ b/content/implementations/HR/info52a.md
@@ -16,6 +16,6 @@ subjectmatter:
 compensation:
 attribution: 
 otherConditions: 
-remarks: "Although the law does not provide for an express reprography exception outside of the opportunity for private copying, paragraph 3 of art. 183 of the Law provides for an 'appropriate compensation' in favour of rightsholders, that is additional to the compensation under the private copying exception (art.183, para 2) and is due by 'natural or **legal persons** who perform photocopying services **for a fee**'."
+remarks: "Although the law does not provide for an express reprography exception outside of the opportunity for private copying, paragraph 3 of art. 183 of the Law provides for an 'appropriate compensation' in favour of rightsholders, that is additional to the compensation under the private copying exception (art.183, para 2) and is due by 'natural or **legal persons** who perform photocopying services **for a fee**'. As per art.185(3), 'irrespective of the fact that they do not have their own exclusive right of reproduction, publishers of written editions have their own right to appropriate compensation for reproduction of their editions for private use'. Under art.185 (4) this 'right to appropriate compensation' last for 50 years from the lawful publication of the work, counting from 1 January of the year immediately following the year of publication."
 link: 
 ---

--- a/content/implementations/HR/info52a.md
+++ b/content/implementations/HR/info52a.md
@@ -16,6 +16,6 @@ subjectmatter:
 compensation:
 attribution: 
 otherConditions: 
-remarks: ""
+remarks: "Although the law does not provide for an express reprography exception outside of the opportunity for private copying, paragraph 3 of art. 183 of the Law provides for an 'appropriate compensation' in favour of rightsholders, that is additional to the compensation under the private copying exception (art.183, para 2) and is due by 'natural or **legal persons** who perform photocopying services **for a fee**'."
 link: 
 ---

--- a/content/implementations/HR/info52a.md
+++ b/content/implementations/HR/info52a.md
@@ -1,28 +1,21 @@
 ---
 title: ""
-date: 2020-12-09T11:39:32+02:00 
-draft: true
+date: 2022-05-06
+draft: false
 weight: 40
 exceptions:
 - info52a
 jurisdictions:
 - HR
-score: 
+score: 0
 description: "" 
 beneficiaries:
-- 
 purposes: 
-- 
 usage:
-- 
 subjectmatter:
-- 
 compensation:
--
 attribution: 
--
 otherConditions: 
-- 
 remarks: ""
 link: 
 ---


### PR DESCRIPTION
Not transposed (at least I cannot find it). The private copying exception includes photocopying, however it is limited to private use by physical persons, therefore I consider it part of 5.2.b. and not 5.2.a.