### PR TITLE
Update info53k.md

### DIFF
--- a/content/implementations/LT/info53k.md
+++ b/content/implementations/LT/info53k.md
@@ -1,5 +1,5 @@
 ---
-title: "Article 58(1), p.12 of the Law No VIII- 1185 on Copyright and Related Rights"
+title: "Article 21' of the Law No VIII- 1185 on Copyright and Related Rights"
 date: 2003-03-05
 draft: false
 weight: 61
@@ -7,8 +7,9 @@ exceptions:
 - info53k
 jurisdictions:
 - LT
-score: 1
-description: "This exception allows for the use of performances, phonograms, film fixations and broadcasts for the purpose of caricature or parody. Indicating the source, including the author’s name, is required, whenever possible." 
+score: 3
+description: "211 article. Use of the work for caricature, parody or pastiche
+It is permissible to use a work for caricature, parody or pastiche without the author's or other copyright holder's permission and without royalties. This exception allows for the use of performances, phonograms, film fixations and broadcasts for the purpose of caricature or parody. Indicating the source, including the author’s name, is required, whenever possible." 
 beneficiaries:
 - any user
 purposes: 
@@ -16,6 +17,7 @@ purposes:
 usage:
 - any use
 subjectmatter:
+- works
 - performances
 - phonograms
 - film fixations 
@@ -25,7 +27,7 @@ compensation:
 attribution: 
 - indicating the source, including the author’s name is required, whenever possible
 otherConditions: 
-remarks: "The exception covers no pastiche.<br /><br />The Lithuanian parody exception for copyrighted works was removed in 2011, leaving the corresponding neighbouring rights exception behind. Currently the law, in terms of litteral reading, provides for an exemption for the purposes of parody and caricature solely regarding neighbouring rights.
+remarks: "The pre-existing Lithuanian parody exception for copyrighted works was removed in 2011, leaving the corresponding neighbouring rights exception behind in art. 58(1), p.12. For a time the law, in terms of litteral reading, provided for an exemption for the purposes of parody and caricature solely regarding neighbouring rights. The exception also did not cover pastiche.<br /><br />As of 24 March 2022, in implementation of the CDSM Directive, the parody exception was reintroduced in its full scope as per the InfoSoc directive under art. 21' of the Law. Art. 58(1), p.12 was also amended to include pastiche.
 <br /><br />In a decision (Nr. 3K-3-214/2009), preceding the CJEU Deckmyn case, the Supreme Court of the Republic of Lithuania ruled that the use of a work for the purpose of parody was permitted under the following conditions:<br /> 
 i) the parody is an imitation of the copyrighted work,<br /> 
 ii) the use of a work is humoristic,<br /> 


### PR DESCRIPTION
Info filled in. As of 24 March 2022, in implementation of the CDSM Directive, the parody exception was reintroduced in its full scope as per the InfoSoc directive under art. 21' of the Law.