### PR TITLE
Update info52e.md

### DIFF
--- a/content/implementations/IE/info52e.md
+++ b/content/implementations/IE/info52e.md
@@ -1,28 +1,21 @@
 ---
 title: ""
-date: 2020-12-09T11:39:36+02:00 
-draft: true
+date: 2022-08-02 
+draft: false
 weight: 44
 exceptions:
 - info52e
 jurisdictions:
 - IE
-score: 
+score: 0
 description: "" 
 beneficiaries:
-- 
 purposes: 
-- 
 usage:
-- 
 subjectmatter:
-- 
 compensation:
--
 attribution: 
--
 otherConditions: 
-- 
-remarks: ""
+remarks: "The purpose of use of the provision of art 5(2)(e) of the InfoSoc Directive can be recognised in Section 97 - use for the benefit of 'residents or inmates', as well as in Section 98 - use for the benefit of 'clubs, societies and organisations' with charitable objets or are otherwise concerned with the advancement of religion, education or social welfare. However, both provisions provide exclusively for the acts of 'playing' a recording or causing a sound recording, broadcast or cable programme 'to be heard or viewed' and do not mention reproduction at all."
 link: 
 ---

--- a/content/implementations/IE/info52e.md
+++ b/content/implementations/IE/info52e.md
@@ -16,6 +16,6 @@ subjectmatter:
 compensation:
 attribution: 
 otherConditions: 
-remarks: "The purpose of use of the provision of art 5(2)(e) of the InfoSoc Directive can be recognised in Section 97 - use for the benefit of 'residents or inmates', as well as in Section 98 - use for the benefit of 'clubs, societies and organisations' with charitable objets or are otherwise concerned with the advancement of religion, education or social welfare. However, both provisions provide exclusively for the acts of 'playing' a recording or causing a sound recording, broadcast or cable programme 'to be heard or viewed' and do not mention reproduction at all."
+remarks: "The purpose of use of the provision of art 5(2)(e) of the InfoSoc Directive can be recognised in Section 97 - use for the benefit of 'residents or inmates', as well as in Section 98 - use for the benefit of 'clubs, societies and organisations' with charitable objets or otherwise concerned with the advancement of religion, education or social welfare. However, both provisions provide exclusively for the acts of 'playing' a recording or causing a sound recording, broadcast or cable programme 'to be heard or viewed' and do not mention reproduction at all."
 link: 
 ---


### PR DESCRIPTION
I consider it not transposed. 

The purpose of use of the provision of art 5(2)(e) of the InfoSoc Directive can be recognised in Section 97 - use for the benefit of 'residents or inmates', as well as in Section 98 - use for the benefit of 'clubs, societies and organisations' with charitable objets or are otherwise concerned with the advancement of religion, education or social welfare. However, both provisions provide exclusively for the acts of 'playing' a recording or causing a sound recording, broadcast or cable programme 'to be heard or viewed' and do not mention reproduction at all.