### PR TITLE
Update info53k.md

### DIFF
--- a/content/implementations/DK/info53k.md
+++ b/content/implementations/DK/info53k.md
@@ -1,21 +1,33 @@
 ---
-title: ""
-date: 2021-02-13 
+title: "§ 52c(10) of the Copyright Act"
+date: 2021-06-03
 draft: false
 weight: 61
 exceptions:
 - info53k
 jurisdictions:
 - DK
-score: 0
-description: "" 
+score: 1
+description: "This exception allows for users of online content-sharing services to upload and make available on the online content- sharing services user-generated content containing works and objects to neighbouring rights for the purposes of caricature, parody or pastiche." 
 beneficiaries:
-purposes: 
+- users of online content-sharing services
+purposes:
+- caricature, parody or pastiche
 usage:
+- upload (to online content-sharing services)
+- make available (on online content-sharing services)
 subjectmatter:
+- works
+- performances
+- phonograms
+- film fixations
+- broadcasts
+- press publications
 compensation:
+- no compensation required
 attribution: 
+- the source must be indicated in accordance with the requirements of proper usage
 otherConditions: 
-remarks: ""
-link: 
+remarks: "Until 2021 no parody exception existed in Denmark. With the ammendment of 3 June 2021 the exception was implemented strictly in the scope of art. 17(7) of the CDSM Directive.<br /><br />According to §11(2) of the CA, where a work is used in accordance with an exception, the work may not be altered more extensively than is required for the permitted use. If the work is used publicly, the source shall be indicated in accordance with the requirements of proper usage."
+link: https://www.ft.dk/ripdf/samling/20201/lovforslag/l205/20201_l205_som_vedtaget.pdf
 ---


### PR DESCRIPTION
Modified - new parody exception in the strict scope of art.17

Until 2021 no parody exception existed in Denmark. With the ammendment of 3 June 2021 the exception was implemented strictly in the scope of art. 17(7) of the CDSM Directive.