### PR TITLE
Update dsm5.md

### DIFF
--- a/content/implementations/BE/dsm5.md
+++ b/content/implementations/BE/dsm5.md
@@ -1,5 +1,5 @@
 ---
-title: "Art. XI.191/1 3.º, 4.º, 6.º and 8.º, Art. XI.191/2 1.º, 2.º and 4.º, Art. XI.217/1 3.º, 4.º, 5.º and 7.º, Art. XI.299 §6, Art. XI.310 §4 Code of Economic Law"
+title: "Art. XI.191/1 §1 8.º Code of Economic Law"
 date: 2022-08-01
 draft: false
 weight: 12
@@ -7,49 +7,34 @@ exceptions:
 - dsm5
 jurisdictions:
 - BE
-score: 3
-description: "Belgium introduced various identical exceptions aimed at implementing Article 5 DSM, which permit digital uses for illustration for teaching, under the responsibility of an educational establishment, of copyrighted works (Art. XI.191/1 8.º), copyrighted databases (Art. XI.191/2 4.º), performances, phonograms, film fixations, broadcasts and press publications (Art. XI.217/1 7.º), software (Art. XI.299 §6) and databases protected by sui generis right (Art. XI.310 §4). In addition, it maintained other education exceptions which partially overlap with the scope of protection of those new exceptions: reproduction exceptions for illustration teaching and scientific research that are open to anyone (Art. XI.191/1 3.º, Art. XI.191/2 1.º and Art. XI.217/1 3.º); communication exceptions for illustration teaching and scientific research by recognized establishments (Art. XI.191/1 4.º, Art. XI.191/2 2.º, Art. XI.217/1 4.º); and reproduction and communication exceptions for educational activities by recognized childcare establishments (Art. XI.191/1 6.º and Art. XI.217/1 5.º). None of the exceptions is subject to compensation or licence availability." 
+score: 2
+description: "Belgium introduced various identical exceptions aimed at implementing Article 5 DSM, which permit digital uses for illustration for teaching, under the responsibility of an educational establishment, of copyrighted works (Art. XI.191/1 §1 8.º), copyrighted databases (Art. XI.191/2 §1 4.º), performances, phonograms, film fixations, broadcasts and press publications (Art. XI.217/1 7.º), software (Art. XI.299 §6) and databases protected by sui generis right (Art. XI.310 §4). None of the exceptions is subject to compensation or licence availability." 
 beneficiaries:
-- anyone (exception for reproduction by anyone)
-- by establishments recognized or officially organized for this purpose by the public authorities (exception for communication by recognized establishments)
-- by childcare establishments recognized or officially organized for this purpose by the public authorities (exception for reproduction or communication by recognized childcare establishments)
-- anyone (exception for in-person digital uses under the responsibility of an educational establishment)
-- students and teaching staff of the educational establishment (exception for remote digital uses under the responsibility of an educational establishment)
+- anyone (in-person digital uses under the responsibility of an educational establishment)
+- students and teaching staff of the educational establishment (remote digital uses under the responsibility of an educational establishment)
 
 purposes: 
-- illustration for teaching or scientific research, with non-profit aim (reproduction exception)
-- illustration for teaching or scientific research, with non-profit aim, within the framework of the normal activities of the establishment (exception for communication by recognized establishments)
-- within the framework of the educational activities of the establishment (exception for reproduction or communication by recognized childcare establishments)
-- illustration for teaching, with non-profit aim, under the responsibility of an educational establishment (exception for digital uses under the responsibility of an educational establishment)
+- illustration for teaching, with non-profit aim, under the responsibility of an educational establishment
 
 usage:
-- reproduction (exception for reproduction by anyone)
-- communication (exception for communication by recognized establishments)
-- reproduction or communication (exception for reproduction or communication by recognized childcare establishments)
-- reproduction or communication of works, copyrighted databases, performances, phonograms, film fixations, broadcasts and press publications (exception for digital uses under the responsibility of an educational establishment)
-- reproduction, distribution, translation, adaptation, arrangement and any other transformation, of computer programs (exception for digital uses under the responsibility of an educational establishment)
-- extraction or reuse of databases protected by the sui generis database right (exception for digital uses under the responsibility of an educational establishment)
+- reproduction or communication of works, copyrighted databases, performances, phonograms, film fixations, broadcasts and press publications 
+- reproduction, distribution, translation, adaptation, arrangement and any other transformation, of computer programs 
+- extraction or reuse of databases protected by the sui generis database right 
 
 subjectmatter:
-- works (except musical scores), copyrighted databases, performances, phonograms, film fixations, broadcasts and press publications (exception for reproduction by anyone)
-- works, copyrighted databases, performances, phonograms, film fixations, broadcasts and press publications (exception for communication by recognized establishments; exception for reproduction or communication by recognized childcare establishments)
-- works (except musical scores), copyrighted databases, computer programs, performances, phonograms, film fixations, broadcasts and press publications, databases protected by sui generis database right (exception for digital uses under the responsibility of an educational establishment)
+- works (except musical scores), copyrighted databases, computer programs, performances, phonograms, film fixations, broadcasts and press publications, databases protected by sui generis database right 
 
 compensation:
-- no compensation required (all exceptions)
+- no compensation required
 
 attribution: 
-- the source and the name of the author need to be mentioned, unless this proves impossible (all exceptions)
+- the source and the name of the author need to be mentioned, unless this proves impossible
 
 otherConditions: 
-- technological limitations: communication must be secured by appropriate measures (exception for communication by establishments)
-- technological limitations: remote communication must take place through a secure electronic environment accessible only to students and teaching staff of the educational establishment (exception for digital uses under the responsibility of an educational establishment)
+- technological limitations: remote communication must take place through a secure electronic environment accessible only to students and teaching staff of the educational establishment
 - 3-step test: exceptions applicable to copyrighted works and copyrighted databases are only applicable if they do not harm the normal exploitation of the work or the database nor cause undue harm to the legitimate interests of the right holder (Art. XI.192/3)
 
 remarks: "There is an exception aimed at implementing article 5 of the DSM Directive (Art. XI.191/1 8.º) allowing the reproduction of works (with the exception of musical scores), or the communication to the public of works in the context of their digital use for the purposes of illustration for teaching, provided that the use is justified by the non-profit aim pursued, and provided that such use takes place under the responsibility of an educational establishment, on its premises or in other places, or by means of a secure electronic environment accessible only to students or students and teaching staff of this institution. It should be noted that the exclusion of the reproduction of musical scores from the scope of protection of the exception does not depend on the market availability of licences for such materials, which contradicts article 5(2) of the DSM Directive. The use of works for purposes of illustration for teaching carried out by means of secure electronic environments is deemed to take place only in the Member State in which the establishment of teaching is established. Similar exceptions exist for copyrighted databases (Art. XI.191/2 4.º) and for performances, phonograms, film fixations, broadcasts and press publications (Art. XI.217/1 7.º). Likewise, an exception with similar conditions applies to the exclusive rights over computer programs (Art. XI.299 §6) and databases protected by the sui generis database right (Art. XI.310 §4).<br /><br />
-In addition, there are other exceptions in Belgium law which partially overlap with the uses covered by article 5 of the DSM Directive, which are described below.<br /><br />
-There’s an exception (Art. XI.191/1 3.º) allowing reproduction of works, with the exception of musical scores, for the purposes of illustration for teaching or scientific research, provided that the use is justified by the non-profit aim pursued. Similar exceptions exist for copyrighted databases (Art. XI.191/2 1.º) and for performances, phonograms, film fixations, broadcasts and press publications (Art. XI.217/1 3.º).<br /><br />
-There is an exception (Art. XI.191/1 4.º) allowing the communication to the public of works for the purposes of illustration for teaching or scientific research, by establishments recognized or officially organized for this purpose by the public authorities and provided that this communication is justified by the non-profit purpose pursued, is within the framework of the normal activities of the establishment and is secured by appropriate measures. Similar exceptions exist for copyrighted databases (Art. XI.191/2 2.º) and for performances, phonograms, film fixations, broadcasts and press publications (Art. XI.217/1 4.º).<br /><br />
-There is an exception (Art. XI.191/1 6.º) allowing the reproduction or communication to the public of works by childcare establishments recognized or officially organized for this purpose by the public authorities and insofar as this reproduction or communication to the public is within the framework of the educational activities of these establishments. Similar exceptions exist for performances, phonograms, film fixations, broadcasts and press publications (Art. XI.217/1 5.º). "
+In addition, there are other exceptions in Belgium law which partially overlap with the uses covered by article 5 of the DSM Directive, which are described below."
 link: https://www.ejustice.just.fgov.be/eli/loi/2013/02/28/2013A11134/justel#Art.XI.191/1
 ---


### PR DESCRIPTION
Aligns title with the remaining exceptions (only mentions the main copyright provision). Reduces score. Deletes description of overlapping exceptions.